### PR TITLE
CI bumps & fix tryparse for BoundNumber

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -68,7 +68,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundTypes"
 uuid = "ff833f9a-10fd-491c-ad5c-961b556a6c53"
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/bound_number/bound_number.jl
+++ b/src/bound_number/bound_number.jl
@@ -19,7 +19,15 @@ Base.eltype(x::BoundNumber) = eltype(typeof(x))
 
 Base.convert(::Type{T}, x::BoundNumber) where {T<:Number} = T(bound_value(x))
 
-Base.tryparse(::Type{T}, x::String) where {T<:BoundNumber} = convert(T, (tryparse(bound_type(T), x)))
+function Base.tryparse(::Type{T}, x::String) where {T<:BoundNumber}
+    result = tryparse(bound_type(T), x)
+    result === nothing && return nothing
+    return try
+        convert(T, result)
+    catch
+        nothing
+    end
+end
 
 for op in [:+, :-, :/, :*, :^]
     @eval Base.$op(x::BoundNumber, y::BoundNumber) = $op(bound_value(x), bound_value(y))


### PR DESCRIPTION
## Summary
- CI dependency bumps (setup-julia, checkout, github-script, codecov, cache)
- Fix `Base.tryparse` for `BoundNumber` — previously crashed when inner `tryparse` returned `nothing`, now correctly propagates `nothing` and catches conversion errors
- Bump version 1.0.4 → 1.0.5

Closes #18
Closes #19
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)