### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BoundTypes"
 uuid = "ff833f9a-10fd-491c-ad5c-961b556a6c53"
-version = "1.0.5"
+version = "1.0.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Release merged test/CI changes (#24) under a proper version bump.